### PR TITLE
Implement LineNo

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -81,7 +81,9 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         end
         
         function [] = readLog(obj)
-        % Open file, read all data, count number of headers = number of messages, process data, close file
+        % Open file, read all data, close file,
+        % Find message headers, find FMT messages, create LogMsgGroup for each FMT msg,
+        % Count number of headers = number of messages, process data
 
             % Open a file at [filePathName filesep fileName]
             [obj.fileID, errmsg] = fopen([obj.filePathName, filesep, obj.fileName], 'r');
@@ -154,7 +156,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
             disp('Done processing.');
         end
         
-        function headerIndices = discoverMSG(obj,msgId,msgLen,headerIndices)
+        function headerIndices = discoverValidMsgHeaders(obj,msgId,msgLen,headerIndices)
             % Parses the whole log file and find the indices of all the msgs
             % Cross-references with the length of each message
                 
@@ -205,12 +207,11 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         end
 
         function data = isolateMsgData(obj,msgId,msgLen,allHeaderCandidates)
-            % Return an msgLen x N array of msgs entries with msgId
-            
-            msgIndices = obj.discoverMSG(msgId,msgLen,allHeaderCandidates);
-            
-            % Generate the N x msgLen array  which corresponds to the indicse where
-            % FMT information exists
+        % Return an msgLen x N array of valid msg data corresponding to msgId
+
+            % Remove invalid header candidates
+            msgIndices = obj.discoverValidMsgHeaders(msgId,msgLen,allHeaderCandidates);
+            % Generate the N x msgLen array which corresponds to the indices where FMT information exists
             indexArray = ones(length(msgIndices),1)*(3:(msgLen-1)) + msgIndices'*ones(1,msgLen-3);
             % Vectorize it into an 1 x N*msgLen vector
             indexVector = reshape(indexArray',[1 length(msgIndices)*(msgLen-3)]);

--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -157,8 +157,9 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         function headerIndices = discoverMSG(obj,msgId,msgLen,headerIndices)
             % Parses the whole log file and find the indices of all the msgs
             % Cross-references with the length of each message
-            debug = true;
-%             debug = false;
+                
+            %debug = true;
+            debug = false;
 
             if debug; fprintf('Searching for msgs with id=%d\n',msgId); end
             
@@ -234,11 +235,9 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 
                 % Create dynamic property of Ardupilog with newName
                 addprop(obj, newName);
-                % Instantiate LogMsgGroup class named newName
-                obj.(newName) = LogMsgGroup();
-                % Process FMT data
-                obj.(newName).storeFormat(newType, newName, newLen, newFmt, newLabels);
-                
+                % Instantiate LogMsgGroup class named newName, process FMT data
+                obj.(newName) = LogMsgGroup(newType, newName, newLen, newFmt, newLabels);
+               
                 % Add to obj.fmt_cell and obj.fmt_type_mat (for increased speed)
                 obj.fmt_cell = [obj.fmt_cell; {newType, newName, newLen}];
                 obj.fmt_type_mat = [obj.fmt_type_mat; newType];

--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -134,6 +134,10 @@ classdef LogMsgGroup < dynamicprops
             end
         end
         
+        function [] = setLineNo(obj, LineNo)
+            obj.LineNo = LineNo;
+        end
+        
         function [] = verifyTypeLengths(obj)
             length = 0;
             for varType = obj.format


### PR DESCRIPTION
Want to capture the log's line number in the LineNo property for every LogMsgGroup. This requires saving a record of all valid message headers. Upon sorting all valid headers, the first is LineNo=1, the second is LineNo=2 and so on.

Coding this got a little awkward to also handle filtered messages... if we remove filtered messages completely from the Ardupilog, (issue #32) we might want to re-implement in a more straightforward fashion.