### PR TITLE
More timestamps as dependent

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -19,6 +19,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         FMTID = 128;
         FMTLen = 89;
         valid_msgheader_cell = cell(0); % A cell array for reconstructing LineNo (line-number) for all entries
+        boot_datenum_UTC = NaN; % The MATLAB datenum (days since Jan 00, 0000) at APM microcontroller boot (TimeUS = 0)
     end %properties
     
     methods
@@ -58,6 +59,9 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
             
             % Extract firmware version from MSG fields
             obj.findInfo();
+            
+            % Attempt to find the UTC time of boot (at boot, TimeUS = 0)
+            obj.findBootTimeUTC();
             
             % Clear out the (temporary) properties
             obj.log_data = char(0);
@@ -291,6 +295,68 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                     end
                 end
             end
+        end
+        
+        function [] = findBootTimeUTC(obj)
+        % From the GPS time, stored in GWk and GMS, calculate what UTC
+        % (Coordinated Universal time) was when the Ardupilot microcontroller
+        % booted. (TimeUS = AP_HAL::millis() = 0)
+            
+        % HGM: It's possible the accuracy of this can be improved. I'll put the
+        % details of my idea here in the comments, and we can move to a GitHub
+        % issue or whatever as appropriate.
+        %
+        % When a GPS receives data, containing absolute time info (logged in GWk and
+        % GMS) it is timestamped by Ardupilot in microseconds-since-boot.  The
+        % problem is, that timestamp is stored in the GPA log message, while the
+        % GWk/GMS is stored in the GPS log message. The delay between logging the two
+        % (GPS and GPA messages) is probably small, but I don't know if there's any
+        % way to determine what came from the single original data receipt.
+        %
+        % We could ask this be changed in Ardupilot, or we might implement
+        % something to figure it out from the log... for now, I'm neglecting it,
+        % and assuming the GPS message was RECEIVED at it's TimeUS. (Note: the
+        % truth is it was LOGGED at this time, not received)
+            if isprop(obj, 'GPS')
+                % Get the time data from the log
+                recv_timeUS = obj.GPS.TimeUS(1);
+                recv_GWk = obj.GPS.GWk(1);
+                recv_GMS = obj.GPS.GMS(1);
+                % Calculate the gps-time datenum
+                gps_zero_datenum = datenum('1980-01-06 00:00:00.000','yyyy-mm-dd HH:MM:SS.FFF');
+                days_since_gps_zero = recv_GWk*7 + recv_GMS/1e3/60/60/24;
+                recv_gps_datenum = gps_zero_datenum + days_since_gps_zero;
+                % Adjust for leap seconds (disagreement between GPS and UTC)
+                leap_second_table = datenum(...
+                    ['Jul 01 1981'
+                     'Jul 01 1982'
+                     'Jul 01 1983'
+                     'Jul 01 1985'
+                     'Jan 01 1988'
+                     'Jan 01 1990'
+                     'Jan 01 1991'
+                     'Jul 01 1992'
+                     'Jul 01 1993'
+                     'Jul 01 1994'
+                     'Jan 01 1996'
+                     'Jul 01 1997'
+                     'Jan 01 1999'
+                     'Jan 01 2006'
+                     'Jan 01 2009'
+                     'Jul 01 2012'
+                     'Jul 01 2015'], 'mmm dd yyyy');
+                leapseconds = sum(recv_gps_datenum > leap_second_table);
+                recv_utc_datenum = recv_gps_datenum - leapseconds/60/60/24;
+                % Record adjusted time to the log's property
+                obj.boot_datenum_UTC = recv_utc_datenum - recv_timeUS/1e6/60/60/24;
+                
+                %debug = true;
+                debug = false;
+                if debug
+                    disp(['Log began at UTC: ',datestr(obj.boot_datenum_UTC, 31)]);
+                end
+
+            end                
         end
         
         function [] = findFMTLength(obj,allHeaderCandidates)

--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -72,7 +72,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
             %  message filtering.
             if ~isnan(obj.bootDatenumUTC)
                 for prop = properties(obj)'
-                    if ismethod(obj.(prop{1}), 'setBootDatenumUTC')
+                    if isa(obj.(prop{1}), 'LogMsgGroup')
                         obj.(prop{1}).setBootDatenumUTC(obj.bootDatenumUTC);
                     end
                 end
@@ -338,6 +338,8 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 recv_GWk = obj.GPS.GWk(1);
                 recv_GMS = obj.GPS.GMS(1);
                 % Calculate the gps-time datenum
+                %  Ref: http://www.oc.nps.edu/oc2902w/gps/timsys.html
+                %  Ref: https://confluence.qps.nl/display/KBE/UTC+to+GPS+Time+Correction
                 gps_zero_datenum = datenum('1980-01-06 00:00:00.000','yyyy-mm-dd HH:MM:SS.FFF');
                 days_since_gps_zero = recv_GWk*7 + recv_GMS/1e3/60/60/24;
                 recv_gps_datenum = gps_zero_datenum + days_since_gps_zero;

--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -64,6 +64,20 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
             % Attempt to find the UTC time of boot (at boot, TimeUS = 0)
             obj.findBootTimeUTC();
             
+            % Set the bootDatenumUTC for all LogMsgGroups
+            % HGM: This can probably be done better after some code reorganization,
+            %  but for now it works well enough. After refactoring is settled, we
+            %  might set the bootDatenumUTC when we set the LineNo, or when we store
+            %  the TimeUS data, whatever makes sense based on how we decide to handle
+            %  message filtering.
+            if ~isnan(obj.bootDatenumUTC)
+                for prop = properties(obj)'
+                    if ismethod(obj.(prop{1}), 'setBootDatenumUTC')
+                        obj.(prop{1}).setBootDatenumUTC(obj.bootDatenumUTC);
+                    end
+                end
+            end
+            
             % Clear out the (temporary) properties
             obj.log_data = char(0);
             obj.fmt_cell = cell(0);

--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -8,11 +8,11 @@ classdef LogMsgGroup < dynamicprops
     properties (Access = public)
         type = -1; % Numerical ID of message type (e.g. 128=FMT, 129=PARM, 130=GPS, etc.)
         name = ''; % Human readable name of msg group
-        % TimeRel % array of boot-relative time values
-        % Timestamp % array of time values
         LineNo = [];
     end
-    
+    properties (Dependent = true)
+        TimeS; % Time in seconds since boot.
+    end
     methods
         function obj = LogMsgGroup(type_num, type_name, data_length, format_string, field_names_string)
             if nargin == 0
@@ -148,6 +148,15 @@ classdef LogMsgGroup < dynamicprops
             end
         end
         
+        function timeS = get.TimeS(obj)
+            if isprop(obj, 'TimeUS')
+                timeS = obj.TimeUS/1e6;
+            elseif isprop(obj, 'TimeMS')
+                timeS = obj.TimeMS/1e3;
+            else
+                timeS = NaN(size(obj.LineNo));
+            end
+        end
     end
 end
 

--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -4,6 +4,7 @@ classdef LogMsgGroup < dynamicprops
         format = ''; % Format string of data (e.g. QBIHBcLLefffB, QccCfLL, etc.)
         fieldInfo = []; % Array of meta.DynamicProperty items
         fieldNameCell = {}; % Cell-array of field names, to reduce run-time
+        bootDatenumUTC = NaN; % The datenum at boot, set by Ardupilog
     end
     properties (Access = public)
         type = -1; % Numerical ID of message type (e.g. 128=FMT, 129=PARM, 130=GPS, etc.)
@@ -12,6 +13,7 @@ classdef LogMsgGroup < dynamicprops
     end
     properties (Dependent = true)
         TimeS; % Time in seconds since boot.
+        DatenumUTC; % MATLAB datenum of UTC Time at boot
     end
     methods
         function obj = LogMsgGroup(type_num, type_name, data_length, format_string, field_names_string)
@@ -138,6 +140,10 @@ classdef LogMsgGroup < dynamicprops
             obj.LineNo = LineNo;
         end
         
+        function [] = setBootDatenumUTC(obj, bootDatenumUTC)
+            obj.bootDatenumUTC = bootDatenumUTC;
+        end
+        
         function [] = verifyTypeLengths(obj)
             length = 0;
             for varType = obj.format
@@ -156,6 +162,10 @@ classdef LogMsgGroup < dynamicprops
             else
                 timeS = NaN(size(obj.LineNo));
             end
+        end
+        
+        function datenumUTC = get.DatenumUTC(obj)
+            datenumUTC = obj.bootDatenumUTC + obj.TimeS/60/60/24;
         end
     end
 end


### PR DESCRIPTION
This is a first attempt at implementing TimeS and UTC time as dependent properties. As we begin to use these, we will likely evolve how they're implemented internally.

I ran into a number of issues for discussion, so I've put comments in the code and I'll summarize them here:
1) We had envisioned TimeUTC as the dependent property, but I wasn't sure how we would implement that? I used instead DatenumUTC, using MATLAB's datenum, which is the number of days since Jan 00, year 0000.
2) For this first-attempt, I assume that the first GPS log message (containing GWk and GMS info) was received at its TimeUS timestamp. Note this is NOT true, as TimeUS measures its time-of-logging, not it's receipt time. (I expect less than a second of error from this.) We can get more accurate by using the GPA messages, or by requesting Ardupilot change some logging, but I went ahead with this for now.
3) Use caution if merging with PRs #46 and #47 , I found some sneaky bugs that made slicing not work correctly. In the future, if we refactor the code further, we might want to modify how/when the bootTimeUTC is passed to all the LogMsgGroups.