### PR TITLE
delete-empty-msgs

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -185,11 +185,11 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 
                 % Check if this message was meant to be filtered
                 if iscellstr(obj.msgFilter)
-                    if ismember(msgName,obj.msgFilter)
+                    if ~isempty(obj.msgFilter) && ~ismember(msgName,obj.msgFilter)
                         continue;
                     end
                 elseif isnumeric(obj.msgFilter)
-                    if ismember(msgId,obj.msgFilter)
+                    if ~isempty(obj.msgFilter) && ~ismember(msgId,obj.msgFilter)
                         continue;
                     end
                 else


### PR DESCRIPTION
I made A LOT of changes this time, so please check that I didn't break anything.
Two major additions:
1. A delete empty msgs function which I cannot make it act on the calling object. It can only return another object
2. A filter function, which allows a message filter to be applied on an existing Ardupilog

Comments and/or patches welcome.

I think I did a bit of a mess this time. I may try to tidy the code up a bit next time.