### PR TITLE
OPTIONAL: format-length assertion

### DIFF
--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -166,12 +166,12 @@ classdef LogMsgGroup < dynamicprops & matlab.mixin.Copyable
             % the sum of the lengths of each (char) format type. (e.g. for 'bbQQ'
             % since 'b'=int8=1byte, 'Q'=uint64=8bytes, the correct length would be
             % 1+1+8+8=18)
-            length = 0;
+            length_sum = 0;
             for varType = obj.format
-                length = length + formatLength(varType);
+                length_sum = length_sum + formatLength(varType);
             end
-            if (length+3 ~= obj.data_len)
-                warning(sprintf('Incompatible declared message type length (%d) and format length (%d) in msg %d/%s',obj.data_len, length+3, obj.type, obj.name));
+            if (length_sum+3 ~= obj.data_len)
+                warning(sprintf('Incompatible declared message type length (%d) and format length (%d) in msg %d/%s',obj.data_len, length_sum+3, obj.type, obj.name));
             end
         end
 

--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -50,6 +50,23 @@ classdef LogMsgGroup < dynamicprops & matlab.mixin.Copyable
         end
 
         function [] = storeData(obj, data)
+        % Store the message data (from the data matrix) into the
+        % appropriate fields based on the column ordering.
+
+            % First, assert that the length(obj.format) == numel(obj.fieldNameCell)
+            if length(obj.format) > numel(obj.fieldNameCell)
+                warning([obj.name, ' format string ', obj.format,...
+                         ' has more (char) elements than defined fields. ',...
+                         'Only using the first ', num2str(numel(obj.fieldNameCell)),...
+                         ': ', obj.format(1:numel(obj.fieldNameCell))]);
+            end
+            if length(obj.format) < numel(obj.fieldNameCell)
+                error([obj.name, ' format string: ', obj.format, ' with length ',...
+                       num2str(length(obj.format)), ' does not provide (char)',...
+                       ' formats for all ', num2str(numel(obj.fieldNameCell)),...
+                       ' field names (in fieldNameCell)'])
+            end
+
             % Format and store the msgData appropriately
             columnIndex = 1;
             for field_ndx = 1:length(obj.fieldInfo)

--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -53,20 +53,6 @@ classdef LogMsgGroup < dynamicprops & matlab.mixin.Copyable
         % Store the message data (from the data matrix) into the
         % appropriate fields based on the column ordering.
 
-            % First, assert that the length(obj.format) == numel(obj.fieldNameCell)
-            if length(obj.format) > numel(obj.fieldNameCell)
-                warning([obj.name, ' format string ', obj.format,...
-                         ' has more (char) elements than defined fields. ',...
-                         'Only using the first ', num2str(numel(obj.fieldNameCell)),...
-                         ': ', obj.format(1:numel(obj.fieldNameCell))]);
-            end
-            if length(obj.format) < numel(obj.fieldNameCell)
-                error([obj.name, ' format string: ', obj.format, ' with length ',...
-                       num2str(length(obj.format)), ' does not provide (char)',...
-                       ' formats for all ', num2str(numel(obj.fieldNameCell)),...
-                       ' field names (in fieldNameCell)'])
-            end
-
             % Format and store the msgData appropriately
             columnIndex = 1;
             for field_ndx = 1:length(obj.fieldInfo)
@@ -162,6 +148,24 @@ classdef LogMsgGroup < dynamicprops & matlab.mixin.Copyable
         end
         
         function [] = verifyTypeLengths(obj)
+            % First, assert that the length(obj.format) == numel(obj.fieldNameCell)
+            if length(obj.format) > numel(obj.fieldNameCell)
+                warning([obj.name, ' format string ', obj.format,...
+                         ' has more (char) elements than defined fields. ',...
+                         'Only using the first ', num2str(numel(obj.fieldNameCell)),...
+                         ': ', obj.format(1:numel(obj.fieldNameCell))]);
+            end
+            if length(obj.format) < numel(obj.fieldNameCell)
+                error([obj.name, ' format string: ', obj.format, ' with length ',...
+                       num2str(length(obj.format)), ' does not provide (char)',...
+                       ' formats for all ', num2str(numel(obj.fieldNameCell)),...
+                       ' field names (in fieldNameCell)'])
+            end
+
+            % Next, verify that the FMT-specified message length agrees with
+            % the sum of the lengths of each (char) format type. (e.g. for 'bbQQ'
+            % since 'b'=int8=1byte, 'Q'=uint64=8bytes, the correct length would be
+            % 1+1+8+8=18)
             length = 0;
             for varType = obj.format
                 length = length + formatLength(varType);


### PR DESCRIPTION
I hope it never will be different, but I coded this up anyways on a whim. I figured it can't hurt to show it to you, even if we choose not to merge it (because it doesn't justify it's added complexity)

When processing a LogMsgGroup, assert that the length of the format string (e.g. QfFFBB) is equal to number of LogMsgGroup fields (e.g. exactly 6, for QfFFBB.)  Throw a warning if format_string is too long (and disregard the extras) but error if it's too short.