### PR TITLE
UNSURE: Changes which support (incorrect) 3DR Solo logs?

### DIFF
--- a/LogMsgGroup.m
+++ b/LogMsgGroup.m
@@ -26,7 +26,19 @@ classdef LogMsgGroup < dynamicprops & matlab.mixin.Copyable
         end
         
         function [] = storeFormat(obj, type_num, type_name, data_length, format_string, field_names_string)
-            obj.fieldNameCell = strsplit(field_names_string,',');
+            if isempty(field_names_string)
+                obj.fieldNameCell = {};
+            else
+                obj.fieldNameCell = strsplit(field_names_string,',');
+            end
+            
+            % Verify that format and labels agree
+            if length(format_string)~=length(obj.fieldNameCell)
+                warning('incompatible data on msg type=%d/%s', type_num, type_name);
+                obj = []; % Clear the instance and return %TODO this is kind of messy
+                return
+            end
+            
             % For each of the fields
             for ndx = 1:length(obj.fieldNameCell)
                 fieldNameStr = obj.fieldNameCell{ndx};


### PR DESCRIPTION
I modified to use Ardupilog on some 3DR Solo logs, which are similar to the Ardupilot format, but have some slight differences. It would be easier to NOT support these, but I thought I'd let you take a look and have them saved in a Pull Request, even if we don't accept/merge them.

(Line 290ish) I think wrapping the FMT message processing in a "try-catch" might be useful in case any old/new versions of Ardupilot have formatting errors like the Solo did?

(Line 350ish) I think the GPS hack is less useful, probably not worth keeping, or bothering to code well.

(Line 47) I've forgotten why I changed fileparts(which(X)) to just fileparts(X).