### PR TITLE
Automatically parse included unit and multiplier information

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -21,8 +21,6 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         FMTLen = 89;
         valid_msgheader_cell = cell(0); % A cell array for reconstructing LineNo (line-number) for all entries
         bootDatenumUTC = NaN; % The MATLAB datenum (days since Jan 00, 0000) at APM microcontroller boot (TimeUS = 0)
-        unitsLookupCell; % N x 2 cell array. Each row has a unit identifier and its string representation
-        multsLookupArray; % N x 2 array. Each row has a multiplier identifier and its equivalent multiplier
 
     end %properties
     
@@ -165,7 +163,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                             continue;
                         end
                     elseif isnumeric(obj.msgFilter)
-                        if ~ismember(msgId,obj.msgFilter);
+                        if ~ismember(msgId,obj.msgFilter)
                             continue;
                         end
                     else

--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -6,6 +6,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         version % Firmware version
         commit % Specific git commit
         bootTimeUTC % String displaying time of boot in UTC
+        msgsContained = {}; % A cell array with all the message names contained in the log
         totalLogMsgs = 0; % Total number of messages of the original log
         msgFilter = []; % Storage for the msgIds/msgNames desired for parsing
         numMsgs = 0; % Number of messages included in this log
@@ -20,6 +21,8 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         FMTLen = 89;
         valid_msgheader_cell = cell(0); % A cell array for reconstructing LineNo (line-number) for all entries
         bootDatenumUTC = NaN; % The MATLAB datenum (days since Jan 00, 0000) at APM microcontroller boot (TimeUS = 0)
+        unitsLookupCell; % N x 2 cell array. Each row has a unit identifier and its string representation
+        multsLookupArray; % N x 2 array. Each row has a multiplier identifier and its equivalent multiplier
 
     end %properties
     
@@ -174,6 +177,12 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 obj.(msgName).storeData(data');
             end
             
+            % If available, parse unit formatting messages
+            availableFields = fieldnames(obj);
+            if (ismember('UNIT', availableFields) && ismember('MULT', availableFields) && ismember('FMTU', availableFields))
+                obj.buildMsgUnitFormats();
+            end
+            
             % Construct the LineNo for the whole log
             LineNo_ndx_vec = sort(vertcat(obj.valid_msgheader_cell{:,2}));
             LineNo_vec = [1:length(LineNo_ndx_vec)]';
@@ -306,6 +315,7 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 if isempty(new_msg_group)
                     warning('Msg group %d/%s could not be created', newType, newName);
                 else
+                    obj.msgsContained{end+1} = newName;
                     addprop(obj, newName);
                     obj.(newName) = new_msg_group;
                 end
@@ -320,6 +330,52 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
             FMTName = obj.fmt_cell{fmt_ndx, 2};
             % Store msgData correctly in that LogMsgGroup
             obj.(FMTName).storeData(data);
+        end
+        
+        function [] = buildMsgUnitFormats(obj)
+            % Read the FMTU messages
+            fmtTypes = obj.FMTU.FmtType;
+            unitIds = obj.FMTU.UnitIds;
+            multIds = obj.FMTU.MultIds;
+            
+            % Read UNIT data
+            UNITId = obj.UNIT.Id;
+            UNITLabel = obj.UNIT.Label;            
+            % Read MULT data
+            MULTId = obj.MULT.Id;
+            MULTMult = obj.MULT.Mult;
+            
+            % Build a msgId to msgName lookup table
+            msgIds = zeros(1,length(obj.msgsContained));
+            for msgIdx = 1:length(msgIds)
+                msgName = obj.msgsContained{msgIdx};
+                msgIds(msgIdx) = obj.(msgName).typeNumID;
+            end
+            
+            % Iterate over each FMTU message
+            for fmtIdx = 1:length(fmtTypes)
+                msgId = fmtTypes(fmtIdx);
+                msgIdx = find(msgIds==msgId, 1, 'first');
+                msgName = obj.msgsContained{msgIdx};
+                currentUnitIds = trimTail(unitIds(fmtIdx,:));
+                currentMultIds = trimTail(multIds(fmtIdx,:));
+                unitNames = cell(1,length(currentUnitIds));
+                multValues = zeros(1,length(currentMultIds));
+                % Iterate over each message field
+                for unitIdx = 1:length(currentUnitIds)
+                    % Lookup unit identifier
+                    idx = find(UNITId==currentUnitIds(unitIdx));
+                    unitName = trimTail(UNITLabel(idx,:));
+                    unitNames{unitIdx} = unitName;
+                    % Lookup multiplier identifier
+                    idx = find(MULTId==currentMultIds(unitIdx));
+                    multValue = MULTMult(idx);
+                    multValues(unitIdx) = multValue;
+                end
+                % Pass the information into the LogMsgGroup
+                obj.(msgName).setUnitNames(unitNames);
+                obj.(msgName).setMultValues(multValues);
+            end
         end
         
         function [] = findInfo(obj)
@@ -553,15 +609,11 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         % Filter message groups in existing Ardupilog
         
         % Get the logMsgGroups names and ids
-        msgNames = {};
-        msgIds = [];
-        propNames = properties(obj);
-        for i=1:length(propNames)
-            propName = propNames{i};
-            if isa(obj.(propName),'LogMsgGroup')
-                msgNames{end+1} = propName;
-                msgIds(end+1) = obj.(propName).typeNumID;
-            end
+        msgNames = obj.msgsContained;
+        msgIds = zeros(1,length(msgNames));
+        for i=1:length(msgNames)
+            msgName = msgNames{i};
+            msgIds(i) = obj.(msgName).typeNumID;
         end
         
         % Check for validity of the input msgFilter
@@ -581,36 +633,37 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
         
         newlog = copy(obj); % Create the new log object
         newlog.msgFilter = msgFilter;
+        deletedMsgNames = cell(1,length(msgFilter));
         % Set the LineNos of any messages due for deletion to empty
-        propertyNames = properties(newlog);
-        for i = 1:length(propertyNames)
-            propertyName = propertyNames{i};
-            if isa(newlog.(propertyName),'LogMsgGroup'); % For each message group
-                msgId = newlog.(propertyName).typeNumID;
-                if iscellstr(newlog.msgFilter)
-                    if ~ismember(propertyName,newlog.msgFilter)
-                        newlog.(propertyName).LineNo = []; % Mark the message group for deletion
-                    end
-                elseif isnumeric(newlog.msgFilter)
-                    if ~ismember(msgId,newlog.msgFilter)
-                        newlog.(propertyName).LineNo = []; % Mark the message group for deletion
-                    end
-                else
-                    error('msgFilter type should have passed validation by now and I shouldnt be here');
+        for i = 1:length(msgNames)
+            msgName = msgNames{i};
+            msgId = newlog.(msgName).typeNumID;
+            if iscellstr(newlog.msgFilter)
+                if ~ismember(msgName,newlog.msgFilter)
+                    newlog.(msgName).LineNo = []; % Mark the message group for deletion
+                    deletedMsgNames{i} = msgName;
                 end
+            elseif isnumeric(newlog.msgFilter)
+                if ~ismember(msgId,newlog.msgFilter)
+                    newlog.(msgName).LineNo = []; % Mark the message group for deletion
+                    deletedMsgNames{i} = msgName;
+                end
+            else
+                error('msgFilter type should have passed validation by now and I shouldnt be here');
             end
         end
+        
+        % Update the msgsContained attribute
+        newlog.msgsContained = setdiff(obj.msgsContained, deletedMsgNames);
         
         newlog = newlog.deleteEmptyMsgs();  
         
         % Update the number of actual included messages
         newlog.numMsgs = 0;
-        propNames = properties(newlog);
-        for i = 1:length(propNames)
-            propName = propNames{i};
-            if isa(newlog.(propName),'LogMsgGroup')
-                newlog.numMsgs = newlog.numMsgs + length(newlog.(propName).LineNo);
-            end
+        newMsgNames = newlog.msgsContained;
+        for i = 1:length(newMsgNames)
+            msgName = newMsgNames{i};
+            newlog.numMsgs = newlog.numMsgs + length(newlog.(msgName).LineNo);
         end
         
         end


### PR DESCRIPTION
Newer ardupilot versions carry the UNIT, MULT and FMTU messages, which describe:
UNIT: a set of unit ids and descriptions: https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Logger/LogStructure.h#L78

MULT: a set of raw value multipliers ids and their values: https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Logger/LogStructure.h#L117

FMTU: A message similar to FMT, but which says for each message field its unit ID and its multiplier ID.

This PR reads this information (if available) and creates the .fieldUnits and .fieldMultipliers structures in each LogMsgGroups, containing said information.
Pretty handy, especially for plotting!

Ardupilot.m uses buildMsgUnitFormats() to parse this information and for each message, forward it to the LogMsgGroup.
There, the setUnitNames and setMultvalues take over.

Also, I have stored the message names in each log, to avoid re-searching it every time. Filter functions have been affected.