### PR TITLE
Bugfix/corrupt timestamps

### DIFF
--- a/Ardupilog.m
+++ b/Ardupilog.m
@@ -218,6 +218,17 @@ classdef Ardupilog < dynamicprops & matlab.mixin.Copyable
                 obj.addLogMsgGroupInstances(obj.(msgName));
             end
             
+            % Delete corrupt timestamps
+            for i = 1:size(obj.valid_msgheader_cell,1)
+                % Find msgName from msgId in 1st column
+                msgId = obj.valid_msgheader_cell{i,1};
+                row_in_fmt_cell = vertcat(obj.fmt_cell{:,1})==msgId;
+                msgName = obj.fmt_cell{row_in_fmt_cell,2};
+                if obj.(msgName).data_len > 0
+                    obj.(msgName).fixCorruptTimestamps();
+                end
+            end
+            
             % Update the number of actual included messages
             propNames = properties(obj);
             for i = 1:length(propNames)

--- a/testing/test_logs_2.m
+++ b/testing/test_logs_2.m
@@ -1,0 +1,7 @@
+% Run test_logs.m first to build the "logs" and "log_names" variables.
+
+% Test if GPS instances are correctly parsed
+log_name = 'marcusbarnet.BIN';
+log = logs(ismember(log_names, log_name));
+assert(isprop(log, 'GPS'), 'First GPS instance not found.');
+assert(isprop(log, 'GPS_1'), 'Second GPS instance not found.');


### PR DESCRIPTION
Ardupilog will now automatically detect and filter out local maxima in message timestamps, usually resulting from corrupt samples.

Closes #71.